### PR TITLE
Add function getReadableValues in AbstractEnumType

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -127,6 +127,18 @@ abstract class AbstractEnumType extends Type
     }
 
     /**
+     * Get array of ENUM Values, where ENUM values are keys and their readable versions are values.
+     *
+     * @static
+     *
+     * @return array Array of values with readable format
+     */
+    public static function getReadableValues()
+    {
+        return static::$choices;
+    }
+
+    /**
      * Get value in readable format.
      *
      * @param string $value ENUM value
@@ -150,6 +162,8 @@ abstract class AbstractEnumType extends Type
      * Check if some string value exists in the array of ENUM values.
      *
      * @param string $value ENUM value
+     *
+     * @static
      *
      * @return bool
      */


### PR DESCRIPTION
This function may be very useful. 
For example, the SonataAdminBundle (v3.9) in ListMapper use choices for 'choice' type in this format. It looks like a bug - FormMapper uses a new format of choices, but ListMapper uses old format.